### PR TITLE
Swaps on-error HTML parsing for HTML detection; fixes #13

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -40,3 +40,24 @@ func TestAnalyzerBasicSecrets(t *testing.T) {
 		t.Errorf("Expected first secret kind to be AWSAccessKey; got %s", secrets[0].Kind)
 	}
 }
+
+func TestIsProbablyHTML(t *testing.T) {
+	cases := []struct {
+		in       []byte
+		expected bool
+	}{
+		{[]byte("var foo = bar"), false},
+		{[]byte(" \t\nvar foo = bar"), false},
+		{[]byte("lol this isn't even JavaScript"), false},
+		{[]byte("<!doctype html><html>"), true},
+		{[]byte(" \t\n<div><p>"), true},
+	}
+
+	for _, c := range cases {
+		actual := isProbablyHTML(c.in)
+
+		if actual != c.expected {
+			t.Errorf("want %t for isProbablyHTML(%q); have %t", c.expected, c.in, actual)
+		}
+	}
+}

--- a/cmd/jsluice/testdata/bad-html.html
+++ b/cmd/jsluice/testdata/bad-html.html
@@ -1,0 +1,11 @@
+<script type="text/javascript"> var contextPath = '/somepage.html'; </script>
+
+<html>
+    <head>
+        <title>Test</title>
+    </head>
+
+    <body>
+        <p>Testing broken/non-standard HTML parsing</p>
+    </body>
+</html>


### PR DESCRIPTION
This change swaps out the previous "treat as HTML on JS parse error" behaviour for basic HTML detection.

There may be false-positives from the `isProbablyHTML` function, but that's not an issue provided the false-positives are not JavaScript files, which should be very unlikely.