### PR TITLE
Improves detection of paths in string literals etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.sw*
 cpu.pprof
+go.work

--- a/cmd/jsluice/testdata/no-file-extension.js
+++ b/cmd/jsluice/testdata/no-file-extension.js
@@ -1,0 +1,18 @@
+function C() {
+        return C = (0, o.default)(c().mark(function e(t) {
+                return c().wrap(function (e) {
+                    while (1)
+                        switch (e.prev = e.next) {
+                        case 0:
+                            return e.abrupt("return", (0, i.default)("/admin/article/paging", {
+                                    method: "POST",
+                                    body: t
+                                }));
+                        case 1:
+                        case "end":
+                            return e.stop()
+                        }
+                }, e)
+            })),
+        C.apply(this, arguments)
+    }

--- a/maybeurl.go
+++ b/maybeurl.go
@@ -33,6 +33,13 @@ func MaybeURL(in string) bool {
 		return false
 	}
 
+	// This could be prone to false positives, but it
+	// seems that in the wild most strings that start
+	// with a slash are actually paths
+	if strings.HasPrefix(in, "/") {
+		return true
+	}
+
 	// Let's attempt to parse it as a URL, so we can
 	// do some analysis on the individual parts
 	u, err := url.Parse(in)

--- a/secret-aws.go
+++ b/secret-aws.go
@@ -35,6 +35,10 @@ func awsMatcher() SecretMatcher {
 			return nil
 		}
 
+		if strings.Contains(str, "_") {
+			return nil
+		}
+
 		// Check it matches the regex
 		if !awsKey.MatchString(str) {
 			return nil


### PR DESCRIPTION
As per Issue #6, we currently miss many paths when those paths lack a known file extension etc.

This change attempts to remedy this with a pretty simple check: if a string begins with a forward slash (after passing previous checks for not containing other special characters), it's now considered to be a path.

I was hesitant to make this change at first, but I did an analysis of the JS from several hundred web pages and found that the false-positive rate is generally quite low (around 1%) when compared to the potentially very large number of new paths discovered (almost double what was previously found)