### PR TITLE
Support for multiple urls in url matchers

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -102,7 +102,7 @@ analyzer := jsluice.NewAnalyzer([]byte(`
 analyzer.AddURLMatcher(
     // The first value in the jsluice.URLMatcher struct is the type of node to look for.
     // It can be one of "string", "assignment_expression", or "call_expression"
-    jsluice.URLMatcher{"string", func(n *jsluice.Node) *jsluice.URL {
+    jsluice.SingleURLMatcher("string", func(n *jsluice.Node) *jsluice.URL {
         val := n.DecodedString()
         if !strings.HasPrefix(val, "mailto:") {
             return nil
@@ -112,7 +112,7 @@ analyzer.AddURLMatcher(
             URL:  val,
             Type: "mailto",
         }
-    }},
+    }),
 )
 
 for _, match := range analyzer.GetURLs() {

--- a/examples/urlmatcher/main.go
+++ b/examples/urlmatcher/main.go
@@ -21,7 +21,7 @@ func main() {
 	analyzer.AddURLMatcher(
 		// The first value in the jsluice.URLMatcher struct is the type of node to look for.
 		// It can be one of "string", "assignment_expression", or "call_expression"
-		jsluice.URLMatcher{"string", func(n *jsluice.Node) *jsluice.URL {
+		jsluice.SingleURLMatcher("string", func(n *jsluice.Node) *jsluice.URL {
 			val := n.DecodedString()
 			if !strings.HasPrefix(val, "mailto:") {
 				return nil
@@ -31,7 +31,7 @@ func main() {
 				URL:  val,
 				Type: "mailto",
 			}
-		}},
+		}),
 	)
 
 	for _, match := range analyzer.GetURLs() {

--- a/url-match-jquery.go
+++ b/url-match-jquery.go
@@ -8,7 +8,7 @@ import (
 
 func matchJQuery() URLMatcher {
 
-	return URLMatcher{"call_expression", func(n *Node) *URL {
+	return SingleURLMatcher("call_expression", func(n *Node) *URL {
 		callName := n.ChildByFieldName("function").Content()
 
 		if !slices.Contains(
@@ -127,5 +127,5 @@ func matchJQuery() URLMatcher {
 		}
 
 		return m
-	}}
+	})
 }

--- a/url-match-xhr.go
+++ b/url-match-xhr.go
@@ -34,7 +34,7 @@ func (c *nodeCache) get(k *Node) ([]*Node, bool) {
 func matchXHR() URLMatcher {
 	cache := newNodeCache()
 
-	return URLMatcher{"call_expression", func(n *Node) *URL {
+	return SingleURLMatcher("call_expression", func(n *Node) *URL {
 		callName := n.ChildByFieldName("function").Content()
 
 		// We don't know what the XMLHttpRequest object will be called,
@@ -165,5 +165,5 @@ func matchXHR() URLMatcher {
 		match.Headers = headers
 
 		return match
-	}}
+	})
 }


### PR DESCRIPTION
#### Card
Currently there is no way to return multiple urls from URLMatcher. So it's impossible to get all urls from the following code:
```javascript
const n = i.Z.resource("api/users", {
        create: {
            method: "POST"
        },
        get: {
            method: "GET",
            url: "{userId}"
        },
        list: {
            method: "POST",
            url: "list"
        },
        update: {
            method: "POST",
            url: "update"
        },
        get: {
            method: "DELETE",
            url: "{userId}"
        },
);
```

#### Details
In this PR I added ability to return multiple urls from `URLMatcher`, but without maintaining backward compatibility. More on this in code comments.