### PR TITLE
Switches anonymous structs for map[string]string in secret matchers

### DIFF
--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -11,8 +11,8 @@ func TestAnalyzerBasicURLs(t *testing.T) {
 
 	urls := a.GetURLs()
 
-	if len(urls) != 1 {
-		t.Errorf("Expected exactly 1 URL; got %d", len(urls))
+	if len(urls) < 1 {
+		t.Errorf("Expected at least 1 URL; got %d", len(urls))
 	}
 
 	if urls[0].URL != "/logout" {

--- a/secret-aws.go
+++ b/secret-aws.go
@@ -44,11 +44,8 @@ func awsMatcher() SecretMatcher {
 			return nil
 		}
 
-		data := struct {
-			Key    string `json:"key"`
-			Secret string `json:"secret,omitempty"`
-		}{
-			Key: str,
+		data := map[string]string{
+			"key": str,
 		}
 
 		match := &Secret{
@@ -77,13 +74,13 @@ func awsMatcher() SecretMatcher {
 			if strings.Contains(k, "secret") {
 				// TODO: check format of value
 				// TODO: think of a way to handle multiple secrets in the same object?
-				data.Secret = DecodeString(o.GetStringI(k, ""))
+				data["secret"] = DecodeString(o.GetStringI(k, ""))
 				break
 			}
 		}
 
 		sev := SeverityLow
-		if data.Secret != "" {
+		if data["secret"] != "" {
 			sev = SeverityHigh
 		}
 		return &Secret{

--- a/secret-gcp.go
+++ b/secret-gcp.go
@@ -21,10 +21,8 @@ func gcpKeyMatcher() SecretMatcher {
 			return nil
 		}
 
-		data := struct {
-			Key string `json:"key"`
-		}{
-			Key: str,
+		data := map[string]string{
+			"key": str,
 		}
 
 		match := &Secret{

--- a/secret-github.go
+++ b/secret-github.go
@@ -14,10 +14,8 @@ func githubKeyMatcher() SecretMatcher {
 			return nil
 		}
 
-		data := struct {
-			Key string `json:"key"`
-		}{
-			Key: str,
+		data := map[string]string{
+			"key": str,
 		}
 
 		match := &Secret{

--- a/secret-matchers.go
+++ b/secret-matchers.go
@@ -144,10 +144,8 @@ func AllSecretMatchers() []SecretMatcher {
 				return nil
 			}
 
-			data := struct {
-				Key string `json:"key"`
-			}{
-				Key: value.RawString(),
+			data := map[string]string{
+				"key": value.RawString(),
 			}
 
 			match := &Secret{


### PR DESCRIPTION
When using `jsluice` as a library you may want to do a type assertion on the `Data` field of the `Secret` struct, as it's type is `any`.

A problem occurs because the `Data` field sometimes includes an anonymous struct, and to do a type assertion to another struct the fields, including the tags, must match *exactly*. That's not very user friendly, so here we swap out all anonymous structs for `map[string]string` instead.