### PR TITLE
Adds source code formatting mode

### DIFF
--- a/cmd/jsluice/README.mkd
+++ b/cmd/jsluice/README.mkd
@@ -46,6 +46,7 @@ of expressions like this are replaced with `EXPR` by default, but that can be ch
         * [Custom Secret Matchers](#custom-secret-matchers)
     * [Printing Syntax Trees](#printing-syntax-trees)
     * [Running Queries](#running-queries)
+    * [Formatting JavaScript Source](#formatting-javascript-source)
     * [Using remote files over HTTP](#requesting-files-from-remote-hosts)
     * [Using WARC files](#using-warc-files)
     * [Getting help](#help)
@@ -78,11 +79,12 @@ You can also provide files one-per-line on `stdin`:
 find . -name '*.js' | jsluice <mode> [options]
 ```
 
-`jsluice` has four modes:
+`jsluice` has five modes:
 * `urls` - for extracting URLs and paths
 * `secrets` - for finding secrets and so on
 * `tree` - for printing syntax trees
 * `query` - for running tree-sitter queries
+* `format` - for formatting JavaScript source
 
 Output is in [JSONL](https://jsonlines.org/) format. Piping `jsluice` to a tool
 like [jq](https://jqlang.github.io/jq/) allows for human-readable formatting,
@@ -411,6 +413,23 @@ as output:
 ```
 
 If you don't want that to happen, you can use the `-r`/`--raw-output` flag.
+
+### Formatting JavaScript Source
+
+The `format` mode uses [jsbeautifier-go](https://github.com/ditashi/jsbeautifier-go) to format JavaScript source code:
+
+```
+▶ cat testdata/location.min.js
+function goToLogin(){location.href="/login/"+document.location.hash.substring(1)} let logout=()=>{document.location.replace("/logout")}
+
+▶ jsluice format testdata/location.min.js
+function goToLogin() {
+    location.href = "/login/" + document.location.hash.substring(1)
+}
+let logout = () => {
+    document.location.replace("/logout")
+}
+```
 
 ### Requesting files from remote hosts:
 `jsluice` will detect when an argument is passed to the tool that begins with `http://` or `https://`. These arguments will be used to retrieve the associated files, and work on them in the same process as the local files.

--- a/cmd/jsluice/format.go
+++ b/cmd/jsluice/format.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/BishopFox/jsluice"
+)
+
+func format(opts options, filename string, source []byte, output chan string, errs chan error) {
+
+	analyzer := jsluice.NewAnalyzer(source)
+
+	formatted, err := analyzer.RootNode().Format()
+	if err != nil {
+		errs <- err
+		return
+	}
+
+	output <- formatted
+}

--- a/cmd/jsluice/main.go
+++ b/cmd/jsluice/main.go
@@ -48,6 +48,7 @@ const (
 	modeSecrets = "secrets"
 	modeTree    = "tree"
 	modeQuery   = "query"
+	modeFormat  = "format"
 )
 
 type stringSlice []string
@@ -191,6 +192,7 @@ func main() {
 		modeSecrets: extractSecrets,
 		modeTree:    printTree,
 		modeQuery:   runQuery,
+		modeFormat:  format,
 	}
 
 	if _, exists := modes[mode]; !exists {

--- a/cmd/jsluice/main.go
+++ b/cmd/jsluice/main.go
@@ -42,6 +42,7 @@ type options struct {
 	query           string
 	rawOutput       bool
 	includeFilename bool
+	format          bool
 }
 
 const (
@@ -82,14 +83,14 @@ func init() {
 			"  secrets   Extract secrets and other interesting bits",
 			"  tree      Print syntax trees for input files",
 			"  query     Run tree-sitter a query against input files",
-			"  format    Beautify the JavaScript source using jsbeautifier-go",
+			"  format    Format JavaScript source using jsbeautifier-go",
 			"",
 			"Global options:",
 			"  -c, --concurrency int        Number of files to process concurrently (default 1)",
 			"  -C, --cookie string          Cookies to use when making requests to the specified HTTP based arguments",
 			"  -H, --header string          Headers to use when making requests to the specified HTTP based arguments (can be specified multiple times)",
 			"  -P, --placeholder string     Set the expression placeholder to a custom string (default 'EXPR')",
-			"      --raw-input              Read raw JavaScript source from stdin",
+			"  -j, --raw-input              Read raw JavaScript source from stdin",
 			"  -w, --warc                   Treat the input files as WARC (Web ARChive) files",
 			"",
 			"URLs mode:",
@@ -105,6 +106,7 @@ func init() {
 			"  -q, --query <query>          Tree sitter query to run; e.g. '(string) @matches'",
 			"  -r, --raw-output             Do not convert values to native types",
 			"  -f, --include-filename       Include the filename in the output",
+			"  -F, --format                 Format source code in the output",
 			"",
 			"Examples:",
 			"  jsluice urls -C 'auth=true; user=admin;' -H 'Specific-Header-One: true' -H 'Specific-Header-Two: false' local_file.js https://remote.host/example.js",
@@ -124,7 +126,7 @@ func main() {
 	flag.IntVarP(&opts.concurrency, "concurrency", "c", 1, "Number of files to process concurrently")
 	flag.StringVarP(&opts.cookie, "cookie", "C", "", "Cookie(s) to use when making HTTP requests")
 	flag.VarP(&headers, "header", "H", "Headers to use when making HTTP requests")
-	flag.BoolVar(&opts.rawInput, "raw-input", false, "Read raw JavaScript source from stdin")
+	flag.BoolVarP(&opts.rawInput, "raw-input", "j", false, "Read raw JavaScript source from stdin")
 	flag.StringVarP(&opts.placeholder, "placeholder", "P", "EXPR", "Set the expression placeholder to a custom string")
 	flag.BoolVarP(&opts.help, "help", "h", false, "")
 	flag.BoolVarP(&opts.warc, "warc", "w", false, "")
@@ -142,6 +144,7 @@ func main() {
 	flag.StringVarP(&opts.query, "query", "q", "", "Tree sitter query to run; e.g. '(string) @matches'")
 	flag.BoolVarP(&opts.rawOutput, "raw-output", "r", false, "Do not convert values to native types")
 	flag.BoolVarP(&opts.includeFilename, "include-filename", "f", false, "Include the filename in the output")
+	flag.BoolVarP(&opts.format, "format", "F", false, "Format source code in the output")
 
 	flag.Parse()
 

--- a/cmd/jsluice/query.go
+++ b/cmd/jsluice/query.go
@@ -19,7 +19,14 @@ func runQuery(opts options, filename string, source []byte, output chan string, 
 
 		for k, n := range qr {
 			vals[k] = n.Content()
-			if !opts.rawOutput {
+
+			switch {
+			case opts.format:
+				f, err := n.Format()
+				if err == nil {
+					vals[k] = f
+				}
+			case !opts.rawOutput:
 				vals[k] = n.AsGoType()
 			}
 		}

--- a/cmd/jsluice/testdata/conditional.js
+++ b/cmd/jsluice/testdata/conditional.js
@@ -1,0 +1,1 @@
+var abc = 123; if (abc < 124) { console.log("math is fine") } else { console.log("math is broken")}

--- a/cmd/jsluice/testdata/location.min.js
+++ b/cmd/jsluice/testdata/location.min.js
@@ -1,0 +1,1 @@
+function goToLogin(){location.href="/login/"+document.location.hash.substring(1)} let logout=()=>{document.location.replace("/logout")}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.1
+	github.com/ditashi/jsbeautifier-go v0.0.0-20141206144643-2520a8026a9c
 	github.com/pkg/profile v1.6.0
 	github.com/slyrz/warc v0.0.0-20150806225202-a50edd19b690
 	github.com/smacker/go-tree-sitter v0.0.0-20230720070738-0d0a9f78d8f8

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/andybalholm/cascadia v1.3.2/go.mod h1:7gtRlve5FxPPgIgX36uWBX58OdBsSS6
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/ditashi/jsbeautifier-go v0.0.0-20141206144643-2520a8026a9c h1:+Zo5Ca9GH0RoeVZQKzFJcTLoAixx5s5Gq3pTIS+n354=
+github.com/ditashi/jsbeautifier-go v0.0.0-20141206144643-2520a8026a9c/go.mod h1:HJGU9ULdREjOcVGZVPB5s6zYmHi1RxzT71l2wQyLmnE=
 github.com/pkg/profile v1.6.0 h1:hUDfIISABYI59DyeB3OTay/HxSRwTQ8rB/H83k6r5dM=
 github.com/pkg/profile v1.6.0/go.mod h1:qBsxPvzyUincmltOk6iyRVxHYg4adc0OFOv72ZdLa18=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
This change adds:

* A `format` mode for the command-line tool, using [jsbeautifier-go](https://github.com/ditashi/jsbeautifier-go) for formatting
* The `-F`/`--format` flag for when outputting formatted source code in `query` mode
* The `-j`/`--raw-input` flag to accept raw JS source code on stdin